### PR TITLE
Add support for Palm, Claude-2, Llama2, CodeLlama (100+LLMs)

### DIFF
--- a/evaluation/models/open_ai_base.py
+++ b/evaluation/models/open_ai_base.py
@@ -25,6 +25,7 @@ class OpenAIBase:
         stop_event
     ):
         import openai
+        from litellm import completion
 
         if max_new_tokens is None:
             max_new_tokens = self.max_new_tokens
@@ -38,7 +39,7 @@ class OpenAIBase:
         if stop_event.is_set():
             raise Exception("Stop event is set")
 
-        return openai.ChatCompletion.create(
+        return completion(
             api_base=api_base,
             api_key=api_key,
             model=model_name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ text-generation # for text-generation-inference backend
 einops # required for falcon
 -e git+https://github.com/lm-sys/FastChat.git#egg=fschat # for fastchat models
 openai
+litellm


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM allows you to use any LLM as a drop in replacement for `gpt-3.5-turbo` 

In addition LiteLLM client allows you to:
* A/B test LLMs in production 
* Dynamically control each LLMs prompt, temperature, top_k etc in our UI (no need to re-deploy code)
* Logging to view input/outputs for each LLM

Here's a link to a live demo of litellm client: https://admin.litellm.ai/ 

![liteLLM-Ab-testing](https://github.com/ConvLab/ConvLab-3/assets/29436595/4206cb62-4c83-4ea1-9be2-e5a7dd306048)
